### PR TITLE
[Step-0] Fix: cleared pending trades after risk update, added unit test

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,7 +16,8 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
-    // Clear pending trades so not added again
+
+    // Clear pending trades
     this->pendingTrades.clear();
     return 0;
 }

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -32,14 +32,14 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
 TEST(TradeRiskTrackerTest, TrackerUpdateTest) {
     std::vector<Trade> trackedTrades;
     RiskTracker riskTracker(0, trackedTrades);
-    riskTracker.addTrade(Trade(20,true,3.0));
+    riskTracker.addTrade(Trade(10,true,3.0));
     riskTracker.updateRisk();
-    EXPECT_NEAR(riskTracker.getRisk(),60, 1e-4);
+    EXPECT_NEAR(riskTracker.getRisk(),30, 1e-4);
     //Add another trade
     riskTracker.addTrade(Trade(25,true,4.0));
     riskTracker.updateRisk();
-    EXPECT_NEAR(riskTracker.getRisk(),160, 1e-4);
+    EXPECT_NEAR(riskTracker.getRisk(),130, 1e-4);
     // Update risk without adding trade
     riskTracker.updateRisk();
-    EXPECT_NEAR(riskTracker.getRisk(),160, 1e-4);
+    EXPECT_NEAR(riskTracker.getRisk(),130, 1e-4);
 }


### PR DESCRIPTION
Purpose:
- Fix bug with pending trades

Changes: 
- Fixed bug by clearing pending trades after risk is updated to avoid double counting. 
- Added unit test to ensure coverage

Bug found: 
- I found that the risk updates added all of the previous trades because pending trade never got cleared. 
- Fixed by clearing pending trades.

Struggled:
- Nothing with the bug fix but had issues with configuration of GNUmake and Cmake for M1. 

